### PR TITLE
feat: Enhance market overview API response

### DIFF
--- a/src/routers/market_overview.py
+++ b/src/routers/market_overview.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 import logging
 from typing import List
+import decimal # Added import
 import pandas as pd
 import numpy as np
 from scipy.signal import argrelextrema
@@ -12,9 +13,22 @@ from pydantic import BaseModel
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
+# Helper functions for price precision
+def get_price_precision(price: float) -> int:
+    price_str = str(price)
+    if '.' in price_str:
+        return len(price_str.split('.')[1])
+    return 0
+
+def format_value(value: float | None, precision: int) -> float | None:
+    if value is None:
+        return None
+    # Use decimal for accurate rounding
+    return float(decimal.Decimal(str(value)).quantize(decimal.Decimal('1e-' + str(precision)), rounding=decimal.ROUND_HALF_UP))
+
 class LevelItem(BaseModel):
     level: float
-    description: str
+    strength: int # Changed from description: str
 
 class MarketOverviewItem(BaseModel):
     symbol: str
@@ -81,13 +95,21 @@ async def get_market_overview():
 
                 # Fetch Ticker for current price
                 ticker = await exchange.fetch_ticker(symbol)
-                current_price = ticker['last'] if ticker and 'last' in ticker and ticker['last'] else 0.0
+                current_price_raw = ticker['last'] if ticker and 'last' in ticker and ticker['last'] else 0.0
+
+                if current_price_raw == 0.0:
+                    price_precision = 2 # Default precision
+                else:
+                    price_precision = get_price_precision(current_price_raw)
+                current_price = format_value(current_price_raw, price_precision)
 
                 # Fetch OHLCV data
                 ohlcv = await exchange.fetch_ohlcv(symbol, timeframe='1h', limit=350) # Increased limit for SMA300
                 if not ohlcv:
+                    # Ensure current_price is formatted even if we continue early
+                    formatted_current_price_on_error = format_value(current_price_raw, price_precision if current_price_raw != 0.0 else 2)
                     results.append(MarketOverviewItem(
-                        symbol=symbol, current_price=current_price, ema_21=None, ema_89=None,
+                        symbol=symbol, current_price=formatted_current_price_on_error, ema_21=None, ema_89=None,
                         sma_30=None, sma_150=None, sma_300=None,
                         support_levels=[], resistance_levels=[]
                     ))
@@ -110,58 +132,103 @@ async def get_market_overview():
                         local_lows = df['low'].iloc[low_extrema_indices].unique()
 
                         # Filter, sort, and select support levels
-                        recent_supports = sorted([low for low in local_lows if low < current_price], reverse=True)
-                        for level in recent_supports[:5]:
-                            support_level_items.append(LevelItem(level=level, description="Recent Low"))
+                        # current_price here is already formatted. For comparison with unformatted df values, use current_price_raw
+                        recent_supports = sorted([low for low in local_lows if low < current_price_raw], reverse=True)
+                        for s_level in recent_supports[:5]:
+                            tolerance = s_level * 0.0005 # Use original level for tolerance calculation
+                            touch_count = df['low'].apply(lambda x: abs(x - s_level) <= tolerance).sum()
+                            formatted_level = format_value(s_level, price_precision)
+                            if formatted_level is not None:
+                                support_level_items.append(LevelItem(level=formatted_level, strength=touch_count))
 
                         # Fill with historical lows if needed
                         if len(support_level_items) < 5:
                             num_needed = 5 - len(support_level_items)
-                            existing_levels = {item.level for item in support_level_items}
-                            historical_lows = df['low'][~df['low'].isin(existing_levels)].nsmallest(num_needed).unique()
-                            for level in historical_lows:
-                                if len(support_level_items) < 5:
-                                    support_level_items.append(LevelItem(level=level, description="Historical Low"))
-                                else:
+                            existing_levels = {item.level for item in support_level_items} # These levels are already formatted
+                            # To compare historical_lows (unformatted) with existing_levels (formatted), we format historical_lows before check.
+                            # However, it's simpler to select from df['low'] that are not in the raw values used to create existing_levels.
+                            # For simplicity, we'll re-filter from unique local_lows that are not yet added.
+                            # This part of logic might need refinement if strict non-overlap with formatted levels is critical.
+                            # The current approach uses original unformatted levels for touch calculation and formats right before append.
+
+                            # Let's fetch historical lows again and ensure they are not already processed (based on original value)
+                            processed_s_levels = {sl.level for sl in support_level_items} # these are formatted
+
+                            # Simpler: just get more from historical, format, and add if total < 5
+                            # This might lead to slight overlaps if formatting causes collisions, but acceptable for now.
+
+                            historical_low_candidates = df['low'][~df['low'].isin([item.level for item in support_level_items])].nsmallest(num_needed + 5).unique() # get a few more
+
+                            for h_level in historical_low_candidates:
+                                if len(support_level_items) >= 5:
                                     break
-                            support_level_items.sort(key=lambda x: x.level, reverse=True) # Sort all supports
+                                # Avoid adding a level that, after formatting, would be identical to an existing one
+                                formatted_h_level = format_value(h_level, price_precision)
+                                if formatted_h_level is not None and formatted_h_level not in {item.level for item in support_level_items}:
+                                    if h_level < current_price_raw: # ensure it's still a support
+                                        tolerance = h_level * 0.0005
+                                        touch_count = df['low'].apply(lambda x: abs(x - h_level) <= tolerance).sum()
+                                        support_level_items.append(LevelItem(level=formatted_h_level, strength=touch_count))
+                            support_level_items.sort(key=lambda x: x.level, reverse=True) # Sort all supports, now formatted
 
                         # Find local maxima for resistance levels
                         high_extrema_indices = argrelextrema(df['high'].values, np.greater, order=extrema_order)[0]
                         local_highs = df['high'].iloc[high_extrema_indices].unique()
 
                         # Filter, sort, and select resistance levels
-                        recent_resistances = sorted([high for high in local_highs if high > current_price])
-                        for level in recent_resistances[:5]:
-                            resistance_level_items.append(LevelItem(level=level, description="Recent High"))
+                        # current_price here is already formatted. For comparison with unformatted df values, use current_price_raw
+                        recent_resistances = sorted([high for high in local_highs if high > current_price_raw])
+                        for r_level in recent_resistances[:5]:
+                            tolerance = r_level * 0.0005 # Use original level for tolerance calculation
+                            touch_count = df['high'].apply(lambda x: abs(x - r_level) <= tolerance).sum()
+                            formatted_level = format_value(r_level, price_precision)
+                            if formatted_level is not None:
+                                resistance_level_items.append(LevelItem(level=formatted_level, strength=touch_count))
 
                         # Fill with historical highs if needed
                         if len(resistance_level_items) < 5:
                             num_needed = 5 - len(resistance_level_items)
-                            existing_levels = {item.level for item in resistance_level_items}
-                            historical_highs = df['high'][~df['high'].isin(existing_levels)].nlargest(num_needed).unique()
-                            for level in historical_highs:
-                                if len(resistance_level_items) < 5:
-                                    resistance_level_items.append(LevelItem(level=level, description="Historical High"))
-                                else:
+                            # Similar to supports, fetch more candidates and filter
+                            historical_high_candidates = df['high'][~df['high'].isin([item.level for item in resistance_level_items])].nlargest(num_needed + 5).unique()
+
+                            for h_level in historical_high_candidates:
+                                if len(resistance_level_items) >= 5:
                                     break
-                            resistance_level_items.sort(key=lambda x: x.level) # Sort all resistances
+                                formatted_h_level = format_value(h_level, price_precision)
+                                if formatted_h_level is not None and formatted_h_level not in {item.level for item in resistance_level_items}:
+                                    if h_level > current_price_raw: # ensure it's still a resistance
+                                        tolerance = h_level * 0.0005
+                                        touch_count = df['high'].apply(lambda x: abs(x - h_level) <= tolerance).sum()
+                                        resistance_level_items.append(LevelItem(level=formatted_h_level, strength=touch_count))
+                            resistance_level_items.sort(key=lambda x: x.level) # Sort all resistances, now formatted
 
                     else: # Not enough data for reliable extrema detection, use n-smallest/n-largest
                         logger.info(f"Using n-smallest/n-largest for S/R for {symbol} due to insufficient data for extrema (got {len(df)}, need {min_data_for_extrema})")
                         raw_supports = sorted(df['low'].nsmallest(5).tolist())
                         raw_resistances = sorted(df['high'].nlargest(5).tolist())
-                        support_level_items = [LevelItem(level=sl, description="Historical Low") for sl in raw_supports]
-                        resistance_level_items = [LevelItem(level=rl, description="Historical High") for rl in raw_resistances]
+
+                        support_level_items = []
+                        for sl_raw in raw_supports:
+                            formatted_sl = format_value(sl_raw, price_precision)
+                            if formatted_sl is not None:
+                                # For these, actual touch count might be low as they are just n-smallest/largest
+                                # Assign strength 1 as per requirement
+                                support_level_items.append(LevelItem(level=formatted_sl, strength=1))
+
+                        resistance_level_items = []
+                        for rl_raw in raw_resistances:
+                            formatted_rl = format_value(rl_raw, price_precision)
+                            if formatted_rl is not None:
+                                resistance_level_items.append(LevelItem(level=formatted_rl, strength=1))
 
                 if len(df) < 300: # Minimum needed for all TAs
                     logger.warning(f"Not enough data points for {symbol} to calculate all TAs (need 300, got {len(df)}). Skipping TA calculations.")
-                    # Support and resistance already calculated above if possible
+                    # Support and resistance already calculated above if possible (and formatted)
                     results.append(MarketOverviewItem(
-                        symbol=symbol, current_price=current_price, ema_21=None, ema_89=None,
+                        symbol=symbol, current_price=current_price, ema_21=None, ema_89=None, # current_price is already formatted
                         sma_30=None, sma_150=None, sma_300=None,
-                        support_levels=support_level_items, # Use already computed S/R
-                        resistance_levels=resistance_level_items # Use already computed S/R
+                        support_levels=support_level_items,
+                        resistance_levels=resistance_level_items
                     ))
                     continue
 
@@ -172,35 +239,41 @@ async def get_market_overview():
                 df['sma_150'] = df.ta.sma(length=150)
                 df['sma_300'] = df.ta.sma(length=300)
 
-                latest_ema_21 = df['ema_21'].iloc[-1]
-                latest_ema_89 = df['ema_89'].iloc[-1]
-                latest_sma_30 = df['sma_30'].iloc[-1]
-                latest_sma_150 = df['sma_150'].iloc[-1]
-                latest_sma_300 = df['sma_300'].iloc[-1]
-
-                # Support and resistance levels are already calculated above using the new logic
-                # So, we just pass support_level_items and resistance_level_items
+                raw_ema_21 = df['ema_21'].iloc[-1]
+                formatted_ema_21 = format_value(raw_ema_21, price_precision) if pd.notna(raw_ema_21) else None
+                raw_ema_89 = df['ema_89'].iloc[-1]
+                formatted_ema_89 = format_value(raw_ema_89, price_precision) if pd.notna(raw_ema_89) else None
+                raw_sma_30 = df['sma_30'].iloc[-1]
+                formatted_sma_30 = format_value(raw_sma_30, price_precision) if pd.notna(raw_sma_30) else None
+                raw_sma_150 = df['sma_150'].iloc[-1]
+                formatted_sma_150 = format_value(raw_sma_150, price_precision) if pd.notna(raw_sma_150) else None
+                raw_sma_300 = df['sma_300'].iloc[-1]
+                formatted_sma_300 = format_value(raw_sma_300, price_precision) if pd.notna(raw_sma_300) else None
 
                 results.append(MarketOverviewItem(
-                    symbol=symbol, current_price=current_price,
-                    ema_21=latest_ema_21 if pd.notna(latest_ema_21) else None,
-                    ema_89=latest_ema_89 if pd.notna(latest_ema_89) else None,
-                    sma_30=latest_sma_30 if pd.notna(latest_sma_30) else None,
-                    sma_150=latest_sma_150 if pd.notna(latest_sma_150) else None,
-                    sma_300=latest_sma_300 if pd.notna(latest_sma_300) else None,
-                    support_levels=support_level_items, # Use already computed S/R
-                    resistance_levels=resistance_level_items # Use already computed S/R
+                    symbol=symbol, current_price=current_price, # current_price is already formatted
+                    ema_21=formatted_ema_21,
+                    ema_89=formatted_ema_89,
+                    sma_30=formatted_sma_30,
+                    sma_150=formatted_sma_150,
+                    sma_300=formatted_sma_300,
+                    support_levels=support_level_items, # Already formatted
+                    resistance_levels=resistance_level_items # Already formatted
                 ))
 
             except ccxt.NetworkError as e:
                 logger.error(f"Network error for {symbol} on {exchange_id}: {e}. Default data returned.")
-                results.append(MarketOverviewItem(symbol=symbol, current_price=0.0, ema_21=None, ema_89=None, sma_30=None, sma_150=None, sma_300=None, support_levels=[], resistance_levels=[]))
+                # Ensure current_price is formatted (0.0 becomes 0.00 if precision is 2)
+                formatted_current_price_on_error = format_value(0.0, 2) # Default to 2 for error cases with 0.0 price
+                results.append(MarketOverviewItem(symbol=symbol, current_price=formatted_current_price_on_error, ema_21=None, ema_89=None, sma_30=None, sma_150=None, sma_300=None, support_levels=[], resistance_levels=[]))
             except ccxt.ExchangeError as e:
                 logger.error(f"Exchange error for {symbol} on {exchange_id}: {e}. Default data returned.")
-                results.append(MarketOverviewItem(symbol=symbol, current_price=0.0, ema_21=None, ema_89=None, sma_30=None, sma_150=None, sma_300=None, support_levels=[], resistance_levels=[]))
+                formatted_current_price_on_error = format_value(0.0, 2)
+                results.append(MarketOverviewItem(symbol=symbol, current_price=formatted_current_price_on_error, ema_21=None, ema_89=None, sma_30=None, sma_150=None, sma_300=None, support_levels=[], resistance_levels=[]))
             except Exception as e:
                 logger.error(f"An unexpected error occurred for {symbol} on {exchange_id}: {e}. Default data returned.")
-                results.append(MarketOverviewItem(symbol=symbol, current_price=0.0, ema_21=None, ema_89=None, sma_30=None, sma_150=None, sma_300=None, support_levels=[], resistance_levels=[]))
+                formatted_current_price_on_error = format_value(0.0, 2)
+                results.append(MarketOverviewItem(symbol=symbol, current_price=formatted_current_price_on_error, ema_21=None, ema_89=None, sma_30=None, sma_150=None, sma_300=None, support_levels=[], resistance_levels=[]))
 
     finally:
         for ex_id, ex_instance in active_exchanges.items():


### PR DESCRIPTION
This commit introduces two main improvements to the /market-overview/ endpoint:

1.  **S/R Level Strength:**
    - The `LevelItem` model now includes a `strength` field instead of `description`.
    - Strength is calculated as the number of times an hourly low/high price point (from 350h of data) is within a 0.05% tolerance of the identified support/resistance level.
    - This provides a quantitative measure of how often a level has been historically significant within the given data window.
    - For levels identified when insufficient data exists for robust extrema detection, a default strength of 1 is assigned.

2.  **Uniform Price Precision:**
    - All price-related values in the `MarketOverviewItem` (current_price, EMAs, SMAs, and S/R levels) are now formatted to have the same number of decimal places as the `current_price` of the respective symbol.
    - If `current_price` is 0.0 (e.g., due to an API error for a symbol), a default precision of 2 decimal places is used.
    - Helper functions `get_price_precision` and `format_value` (using `decimal` module for accuracy) were added to handle this.

These changes address the issue of uninformative S/R descriptions and inconsistent decimal places in the API output.