### PR TITLE
feat: Implement order listing and investment summary APIs

### DIFF
--- a/src/crud/orders.py
+++ b/src/crud/orders.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import Session
+from datetime import datetime # Added import
 from src.database.models import Order
 from src.schemas.order_schema import OrderCreate
 
@@ -60,3 +61,48 @@ def get_orders(db: Session, skip: int = 0, limit: int = 100) -> list[Order]:
     (Optional, for admin or general listing)
     """
     return db.query(Order).offset(skip).limit(limit).all()
+
+def get_orders_with_filters(
+    db: Session,
+    exchange_id: str | None = None,
+    symbol: str | None = None,
+    status: str | None = None,
+    skip: int = 0,
+    limit: int = 100
+) -> list[Order]:
+    """
+    Retrieves orders from the database with optional filters and pagination.
+    """
+    query = db.query(Order)
+
+    if exchange_id:
+        query = query.filter(Order.exchange_id == exchange_id)
+    if symbol:
+        query = query.filter(Order.symbol == symbol)
+    if status:
+        query = query.filter(Order.status == status)
+
+    # Add ordering, e.g., by timestamp descending, for consistent pagination
+    query = query.order_by(Order.timestamp.desc()) # type: ignore
+
+    return query.offset(skip).limit(limit).all()
+
+def get_filled_buy_orders_for_summary(
+    db: Session,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None
+) -> list[Order]:
+    """
+    Retrieves 'buy' orders with status 'filled', optionally within a date range.
+    These orders are used for calculating investment summaries.
+    """
+    query = db.query(Order).filter(Order.side == 'buy', Order.status == 'filled')
+
+    if start_date:
+        query = query.filter(Order.timestamp >= start_date) # type: ignore
+    if end_date:
+        query = query.filter(Order.timestamp <= end_date) # type: ignore
+
+    # Orders should have a cost associated with them, which is price * amount.
+    # No specific ordering needed here as the service layer will aggregate.
+    return query.all()

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from src.routers import exchange, trades, market_overview, orders  # Added orders router
+from src.routers import exchange, trades, market_overview, orders, investment # Added investment router
 from src.database.session import create_db_and_tables  # For DB initialization
 
 app = FastAPI()
@@ -15,6 +15,7 @@ app.include_router(exchange.router)
 app.include_router(trades.router)  # Added trades router
 app.include_router(market_overview.router, prefix="/market", tags=["market"])
 app.include_router(orders.router)  # Added orders router, prefix is in orders.py
+app.include_router(investment.router) # Added investment router, prefix is in investment.py
 
 
 @app.get("/health")

--- a/src/routers/investment.py
+++ b/src/routers/investment.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from src.database.session import get_db
+from src.schemas.investment_schema import InvestmentSummaryResponse # Request params will be query params
+from src.services import investment_tracker
+import logging
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/v1/investment_summary", # Changed prefix
+    tags=["investment_summary"], # Changed tag
+    responses={404: {"description": "Not found"}},
+)
+
+@router.get("/", response_model=InvestmentSummaryResponse) # Changed path to /
+async def get_investment_summary_api(
+    timeframe: str = Query('total', enum=['daily', 'weekly', 'total'], description="Timeframe for the summary: 'daily', 'weekly', or 'total'."),
+    currency: str = Query('USD', enum=['USD', 'BTC'], description="Currency for the summary: 'USD' or 'BTC'. Currently, only 'USD' is fully supported."),
+    db: Session = Depends(get_db)
+):
+    """
+    Calculate and return investment summary metrics.
+    - **timeframe**: Aggregation period ('daily', 'weekly', 'total'). Default: 'total'.
+    - **currency**: Currency for reporting ('USD', 'BTC'). Default: 'USD'.
+                     Note: BTC calculation is not yet fully implemented.
+    """
+    try:
+        summary_response = await investment_tracker.calculate_investment_summary(
+            db=db,
+            timeframe=timeframe,
+            currency=currency
+        )
+        return summary_response
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    except ValueError as e: # For invalid timeframe
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error calculating investment summary: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"An unexpected error occurred while calculating the investment summary: {str(e)}"
+        )

--- a/src/schemas/investment_schema.py
+++ b/src/schemas/investment_schema.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel
+from typing import Optional, List, Dict
+from datetime import date, datetime
+
+class InvestmentSummaryRequest(BaseModel):
+    timeframe: Optional[str] = 'total'  # e.g., 'daily', 'weekly', 'total'
+    currency: Optional[str] = 'USD'    # e.g., 'USD', 'BTC'
+
+class InvestmentDataPoint(BaseModel):
+    period: str  # Could be a date for daily, week_number for weekly, or 'total'
+    total_invested: float
+    currency: str
+
+class InvestmentSummaryResponse(BaseModel):
+    requested_timeframe: str
+    requested_currency: str
+    summary: List[InvestmentDataPoint]
+    # Optional: Add more fields like overall_total_invested if needed
+    overall_total_invested: Optional[float] = None
+    calculation_timestamp: datetime
+
+    class Config:
+        orm_mode = True # For Pydantic V1
+        # from_attributes = True # For Pydantic V2
+        pass

--- a/src/services/investment_tracker.py
+++ b/src/services/investment_tracker.py
@@ -1,0 +1,94 @@
+from sqlalchemy.orm import Session
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict, Any
+from collections import defaultdict
+
+from src.schemas.investment_schema import InvestmentSummaryResponse, InvestmentDataPoint
+from src.crud import orders as crud_orders # Assuming function will be in crud_orders
+# from src.crud import trades as crud_trades # If using trades table directly
+
+import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+async def calculate_investment_summary(
+    db: Session,
+    timeframe: str = 'total',
+    currency: str = 'USD'
+) -> InvestmentSummaryResponse:
+    """
+    Calculates the investment summary based on filled 'buy' orders.
+    Currently supports USD calculations. BTC conversion is a future enhancement.
+    """
+    logger.info(f"Calculating investment summary for timeframe: {timeframe}, currency: {currency}")
+
+    if currency.upper() != 'USD':
+        # For now, only USD is supported as per issue's guidance to start simple.
+        # BTC calculation would require historical price feeds.
+        raise NotImplementedError(f"Currency {currency} is not yet supported for investment summary. Please use USD.")
+
+    # Fetch relevant orders/trades. We need 'buy' orders that are 'filled'.
+    # The 'cost' field in the Order model (price * amount) should represent the invested amount in the quote currency.
+    # We assume the quote currency is USD or a USD-pegged stablecoin (e.g., USDT, USDC).
+
+    # This function will be created in step 4c
+    # For now, we define its expected signature:
+    # filled_buy_orders = crud_orders.get_filled_buy_orders_for_summary(db=db, start_date=None, end_date=None)
+    # The actual implementation of get_filled_buy_orders_for_summary might take date ranges.
+
+    summary_points: List[InvestmentDataPoint] = []
+    overall_total_invested = 0.0
+
+    # Determine date range for querying if not 'total'
+    end_date = datetime.now(timezone.utc)
+    start_date = None
+
+    if timeframe == 'daily':
+        # Let's assume 'daily' means last 30 days for now, or it could be grouped by each day.
+        # For simplicity in this first pass, let's make 'daily' sum up investments for each of the last 30 days.
+        # A more robust implementation might take specific date ranges as parameters.
+        start_date = end_date - timedelta(days=30)
+        # Fetch all filled buy orders within this broad range
+        orders = crud_orders.get_filled_buy_orders_for_summary(db=db, start_date=start_date, end_date=end_date)
+
+        daily_investments: Dict[str, float] = defaultdict(float)
+        for order in orders:
+            if order.timestamp and order.cost: # Ensure timestamp and cost are not None
+                order_date_str = order.timestamp.strftime('%Y-%m-%d')
+                daily_investments[order_date_str] += order.cost
+
+        for date_str, total in sorted(daily_investments.items()):
+            summary_points.append(InvestmentDataPoint(period=date_str, total_invested=total, currency=currency.upper()))
+            overall_total_invested += total
+
+    elif timeframe == 'weekly':
+        # Let's assume 'weekly' means last 12 weeks.
+        start_date = end_date - timedelta(weeks=12)
+        orders = crud_orders.get_filled_buy_orders_for_summary(db=db, start_date=start_date, end_date=end_date)
+
+        weekly_investments: Dict[str, float] = defaultdict(float)
+        for order in orders:
+            if order.timestamp and order.cost:
+                # Group by ISO week number and year
+                week_str = f"{order.timestamp.isocalendar()[0]}-W{order.timestamp.isocalendar()[1]:02d}"
+                weekly_investments[week_str] += order.cost
+
+        for week_str, total in sorted(weekly_investments.items()):
+            summary_points.append(InvestmentDataPoint(period=week_str, total_invested=total, currency=currency.upper()))
+            overall_total_invested += total
+
+    elif timeframe == 'total':
+        orders = crud_orders.get_filled_buy_orders_for_summary(db=db) # No date filter for total
+        current_total = sum(order.cost for order in orders if order.cost is not None)
+        summary_points.append(InvestmentDataPoint(period='total', total_invested=current_total, currency=currency.upper()))
+        overall_total_invested = current_total
+    else:
+        raise ValueError(f"Unsupported timeframe: {timeframe}. Supported values are 'daily', 'weekly', 'total'.")
+
+    return InvestmentSummaryResponse(
+        requested_timeframe=timeframe,
+        requested_currency=currency.upper(),
+        summary=summary_points,
+        overall_total_invested=overall_total_invested if timeframe not in ['total'] else None, # Only set if not 'total' to avoid redundancy
+        calculation_timestamp=datetime.now(timezone.utc)
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
+from fastapi.testclient import TestClient # Moved import to top
 from src.database.base import Base # Assuming your SQLAlchemy Base is here
 from src.main import app # Your FastAPI app
 from src.database.session import get_db # The dependency to override

--- a/tests/services/test_investment_tracker.py
+++ b/tests/services/test_investment_tracker.py
@@ -1,0 +1,200 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta, timezone
+
+from src.services.investment_tracker import calculate_investment_summary
+from src.schemas.investment_schema import InvestmentSummaryResponse, InvestmentDataPoint
+from src.database.models import Order # Assuming Order model is used for cost calculation
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+@pytest.fixture
+def mock_db_session():
+    return MagicMock()
+
+# Sample order data for mocking CRUD responses
+def create_mock_order(id: int, cost: float, timestamp: datetime, side: str = 'buy', status: str = 'filled'):
+    return Order(
+        id=id,
+        exchange_id="test_exchange",
+        symbol="BTC/USDT",
+        timestamp=timestamp,
+        price=cost, # Assuming price is effectively cost for simplicity here if amount is 1
+        amount=1.0, # Assuming amount is 1 for simplicity in cost calculation
+        side=side,
+        type='limit',
+        status=status,
+        filled_amount=1.0,
+        remaining_amount=0.0,
+        cost=cost, # This is the key field for investment summary
+        fee=cost * 0.001,
+        fee_currency='USDT',
+        is_spot=True
+    )
+
+@patch('src.services.investment_tracker.crud_orders.get_filled_buy_orders_for_summary')
+async def test_calculate_investment_summary_total_usd(mock_get_filled_orders, mock_db_session):
+    now = datetime.now(timezone.utc)
+    mock_orders_data = [
+        create_mock_order(id=1, cost=100.0, timestamp=now - timedelta(days=10)),
+        create_mock_order(id=2, cost=150.0, timestamp=now - timedelta(days=5)),
+    ]
+    mock_get_filled_orders.return_value = mock_orders_data
+
+    summary_response = await calculate_investment_summary(db=mock_db_session, timeframe='total', currency='USD')
+
+    assert summary_response.requested_timeframe == 'total'
+    assert summary_response.requested_currency == 'USD'
+    assert len(summary_response.summary) == 1
+
+    data_point = summary_response.summary[0]
+    assert data_point.period == 'total'
+    assert data_point.total_invested == 250.0 # 100.0 + 150.0
+    assert data_point.currency == 'USD'
+
+    assert summary_response.overall_total_invested is None # Not set for 'total' timeframe
+    assert summary_response.calculation_timestamp is not None
+
+    mock_get_filled_orders.assert_called_once_with(db=mock_db_session)
+
+
+@patch('src.services.investment_tracker.crud_orders.get_filled_buy_orders_for_summary')
+async def test_calculate_investment_summary_daily_usd(mock_get_filled_orders, mock_db_session):
+    now = datetime.now(timezone.utc)
+    # Orders from today, yesterday, and two days ago
+    mock_orders_data = [
+        create_mock_order(id=1, cost=50.0, timestamp=now - timedelta(microseconds=10)), # Today
+        create_mock_order(id=2, cost=60.0, timestamp=now - timedelta(microseconds=20)), # Today
+        create_mock_order(id=3, cost=100.0, timestamp=now - timedelta(days=1)), # Yesterday
+        create_mock_order(id=4, cost=200.0, timestamp=now - timedelta(days=2)), # Two days ago
+        create_mock_order(id=5, cost=10.0, timestamp=now - timedelta(days=35)), # Outside 30 day default range for daily
+    ]
+    # The service function filters by date range *before* grouping.
+    # So, mock_get_filled_orders should be called with start_date and end_date for 'daily'.
+    # We will simulate that the CRUD function returns only relevant orders for the last 30 days.
+
+    # Let's refine this: the service calls CRUD with a date range.
+    # So, the mock should reflect what CRUD returns for that range.
+    # The service expects orders within the last 30 days for 'daily'.
+    relevant_orders = [o for o in mock_orders_data if o.timestamp >= (now - timedelta(days=30))]
+    mock_get_filled_orders.return_value = relevant_orders
+
+
+    summary_response = await calculate_investment_summary(db=mock_db_session, timeframe='daily', currency='USD')
+
+    assert summary_response.requested_timeframe == 'daily'
+    assert summary_response.requested_currency == 'USD'
+
+    # Expected daily summary:
+    # Today: 50 + 60 = 110
+    # Yesterday: 100
+    # Two days ago: 200
+    # The order from 35 days ago should be excluded by the date range passed to CRUD.
+
+    expected_daily_totals = {
+        (now - timedelta(days=2)).strftime('%Y-%m-%d'): 200.0,
+        (now - timedelta(days=1)).strftime('%Y-%m-%d'): 100.0,
+        now.strftime('%Y-%m-%d'): 110.0,
+    }
+
+    assert len(summary_response.summary) == 3
+    total_invested_from_summary = 0
+    for point in summary_response.summary:
+        assert point.currency == 'USD'
+        assert point.period in expected_daily_totals
+        assert point.total_invested == expected_daily_totals[point.period]
+        total_invested_from_summary += point.total_invested
+
+    assert summary_response.overall_total_invested == total_invested_from_summary # 110 + 100 + 200 = 410
+
+    # Check that CRUD was called with a date range
+    mock_get_filled_orders.assert_called_once()
+    call_args = mock_get_filled_orders.call_args[1] # keyword arguments
+    assert 'start_date' in call_args and call_args['start_date'] is not None
+    assert 'end_date' in call_args and call_args['end_date'] is not None
+
+
+@patch('src.services.investment_tracker.crud_orders.get_filled_buy_orders_for_summary')
+async def test_calculate_investment_summary_weekly_usd(mock_get_filled_orders, mock_db_session):
+    now = datetime.now(timezone.utc)
+
+    # Orders for current week and last week
+    # Week 1 (current):
+    order1_w1 = create_mock_order(id=1, cost=100, timestamp=now - timedelta(days=1)) # e.g. Friday
+    order2_w1 = create_mock_order(id=2, cost=50,  timestamp=now - timedelta(days=2)) # e.g. Thursday
+    # Week 2 (last week):
+    order3_w2 = create_mock_order(id=3, cost=200, timestamp=now - timedelta(days=7)) # e.g. Last Friday
+    order4_w2 = create_mock_order(id=4, cost=25,  timestamp=now - timedelta(days=8)) # e.g. Last Thursday
+    # Order from 13 weeks ago (should be excluded by default 12-week range)
+    order5_w13 = create_mock_order(id=5, cost=1000, timestamp=now - timedelta(weeks=13))
+
+    relevant_orders = [order1_w1, order2_w1, order3_w2, order4_w2]
+    mock_get_filled_orders.return_value = relevant_orders
+
+    summary_response = await calculate_investment_summary(db=mock_db_session, timeframe='weekly', currency='USD')
+
+    assert summary_response.requested_timeframe == 'weekly'
+    assert summary_response.requested_currency == 'USD'
+
+    # Expected weekly summary:
+    current_week_iso = f"{now.isocalendar()[0]}-W{now.isocalendar()[1]:02d}"
+    last_week_date = now - timedelta(weeks=1)
+    last_week_iso = f"{last_week_date.isocalendar()[0]}-W{last_week_date.isocalendar()[1]:02d}"
+
+    expected_weekly_totals = {
+        current_week_iso: 150.0, # 100 + 50
+        last_week_iso: 225.0     # 200 + 25
+    }
+
+    # The order of summary points matters if sorted by week_str
+    # The service sorts them, so we should expect that order.
+    # If last_week_iso < current_week_iso, then it comes first.
+
+    assert len(summary_response.summary) == 2
+    total_invested_from_summary = 0
+
+    # Check that the periods are correct and totals match
+    found_periods = set()
+    for point in summary_response.summary:
+        assert point.currency == 'USD'
+        assert point.period in expected_weekly_totals
+        assert point.total_invested == expected_weekly_totals[point.period]
+        total_invested_from_summary += point.total_invested
+        found_periods.add(point.period)
+
+    assert found_periods == set(expected_weekly_totals.keys())
+    assert summary_response.overall_total_invested == total_invested_from_summary # 150 + 225 = 375
+
+    mock_get_filled_orders.assert_called_once()
+    call_args = mock_get_filled_orders.call_args[1]
+    assert 'start_date' in call_args and call_args['start_date'] is not None
+    assert 'end_date' in call_args and call_args['end_date'] is not None
+
+
+async def test_calculate_investment_summary_unsupported_currency(mock_db_session):
+    with pytest.raises(NotImplementedError) as excinfo:
+        await calculate_investment_summary(db=mock_db_session, timeframe='total', currency='BTC')
+    assert "BTC is not yet supported" in str(excinfo.value)
+
+async def test_calculate_investment_summary_invalid_timeframe(mock_db_session):
+    with pytest.raises(ValueError) as excinfo:
+        await calculate_investment_summary(db=mock_db_session, timeframe='monthly', currency='USD')
+    assert "Unsupported timeframe: monthly" in str(excinfo.value)
+
+@patch('src.services.investment_tracker.crud_orders.get_filled_buy_orders_for_summary')
+async def test_calculate_investment_summary_no_orders(mock_get_filled_orders, mock_db_session):
+    mock_get_filled_orders.return_value = [] # No orders found
+
+    summary_response_total = await calculate_investment_summary(db=mock_db_session, timeframe='total', currency='USD')
+    assert len(summary_response_total.summary) == 1
+    assert summary_response_total.summary[0].total_invested == 0
+    assert summary_response_total.summary[0].period == 'total'
+
+    summary_response_daily = await calculate_investment_summary(db=mock_db_session, timeframe='daily', currency='USD')
+    assert len(summary_response_daily.summary) == 0 # No data points if no orders in range
+    assert summary_response_daily.overall_total_invested == 0
+
+    summary_response_weekly = await calculate_investment_summary(db=mock_db_session, timeframe='weekly', currency='USD')
+    assert len(summary_response_weekly.summary) == 0 # No data points if no orders in range
+    assert summary_response_weekly.overall_total_invested == 0


### PR DESCRIPTION
Implements two new API endpoints as per issue #12:
1. GET /api/v1/orders:
   - Lists orders with optional filtering by exchange_id, symbol, and status.
   - Supports pagination using limit and offset.
   - Includes changes to CRUD layer, service layer, and router.

2. GET /api/v1/investment_summary:
   - Calculates total investment (initially in USD) based on past trades/filled orders.
   - Supports 'total', 'daily', and 'weekly' timeframes.
   - Includes new schemas, service layer, CRUD functions, and router.
   - Registers the new router in main.py.

Also includes:
- Unit tests for the new service functions in order_manager and the new investment_tracker service.
- Numerous fixes to existing tests and service code discovered during testing, related to Pydantic model usage, exception handling, and mock setups.
- Installation of missing dependencies in the testing environment.